### PR TITLE
Update implementation

### DIFF
--- a/storage-available.js
+++ b/storage-available.js
@@ -8,6 +8,17 @@ module.exports = function storageAvailable(type) {
 		return true;
 	}
 	catch(e) {
-		return false;
+            return e instanceof DOMException && (
+                // everything except Firefox
+                e.code === 22 ||
+                // Firefox
+                e.code === 1014 ||
+                // test name field too, because code might not be present
+                // everything except Firefox
+                e.name === 'QuotaExceededError' ||
+                // Firefox
+                e.name === 'NS_ERROR_DOM_QUOTA_REACHED') &&
+                // acknowledge QuotaExceededError only if there's something already stored
+                storage.length !== 0;
 	}
 }


### PR DESCRIPTION
This update takes care of the situation where the storage is supported
by the browser, but it's not actually available.

See a more in-depth explanation and updated implementation at https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#Feature-detecting_localStorage

A reason not to merge this would be that someone might only want to know if the feature is technically supported and doesn't care if it's actually usable. It's hard for me to imagine such a case, but it's possible.