### PR TITLE
Typescript Types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Detect if web storage is available and functional",
   "main": "storage-available.js",
+  "typings": "typings.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,0 +1,2 @@
+
+export default function storageAvailable(type: string): boolean;


### PR DESCRIPTION
Hello,

When using storageAvailable under a Typescript project that has the `noImplicitAny` flag set, an error will be thrown as there is no types defined.

Typescript will complain about the **type** parameter which isn't defined
```js
function storageAvailable(type);
```

This PR add the types on a separate file, not changing any existing code.

